### PR TITLE
Re-fixed the CommonJS entry point in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "emoticon",
     "jquery-embed"
   ],
-  "main": [
-    "./src/jquery.embed.js",
-    "./src/jquery.embed.css"
-  ],
+  "main": "./src/jquery.embed.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/ritz078/embed-js.git"


### PR DESCRIPTION
Please, we need to keep in this way the CommonJS entry point ("package.json" file) to get it working. :)