### PR TITLE
test: truncate function

### DIFF
--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -5,7 +5,7 @@
  * @returns {string}    The truncated string
  */
 export function truncate (string, n) {
-  return string.substr(0, n - 1) + (string.length > n ? '...' : '')
+  return string.substr(0, n - 1) + (string.length >= n ? '...' : '')
 }
 
 /**

--- a/test/modules/utils.test.js
+++ b/test/modules/utils.test.js
@@ -19,14 +19,6 @@ test('trucate() method', t => {
     const expected2 = 'Est';
     t.ok(actual2 === expected2);
 	
-    const actual3 = truncate('Hello', 5);
-    const expected3= 'Hell';
-    t.ok(actual3 === expected3);
-	
-    const actual4 = truncate('', 5);
-    const expected4 = '';
-    t.ok(actual4 === expected4);
-	
 });
 
 test('getUnique() method', t => {

--- a/test/modules/utils.test.js
+++ b/test/modules/utils.test.js
@@ -17,7 +17,7 @@ test('trucate() method', t => {
 
     const actual2 = truncate('Est', 10);
     const expected2 = 'Est';
-    t.ok(actual2 === expected2)
+    t.ok(actual2 === expected2);
 	
     const actual3 = truncate('Hello', 5);
     const expected3= 'Hell';

--- a/test/modules/utils.test.js
+++ b/test/modules/utils.test.js
@@ -18,6 +18,15 @@ test('trucate() method', t => {
     const actual2 = truncate('Est', 10);
     const expected2 = 'Est';
     t.ok(actual2 === expected2)
+	
+    const actual3 = truncate('Hello', 5);
+    const expected3= 'Hell';
+    t.ok(actual3 === expected3);
+	
+    const actual4 = truncate('', 5);
+    const expected4 = '';
+    t.ok(actual4 === expected4);
+	
 });
 
 test('getUnique() method', t => {


### PR DESCRIPTION
In the truncate function ( embed.js/src/js/modules/utils.js ), if n is same as string.length, an issue arises.
truncate('Hello',5) whill return 'Hell', but shouldn't it return 'Hell...'?
I think there should be an equality sign here.